### PR TITLE
torsocks: patch to work with ndk17

### DIFF
--- a/packages/torsocks/src-lib-sendto.c.patch
+++ b/packages/torsocks/src-lib-sendto.c.patch
@@ -1,0 +1,20 @@
+--- ../sendto.c.orig	2018-05-11 10:24:04.435833050 +0000
++++ ./src/lib/sendto.c	2018-05-11 10:45:20.609090437 +0000
+@@ -72,17 +72,3 @@
+ 
+ 	return tsocks_libc_sendto(LIBC_SENDTO_ARGS);
+ }
+-
+-/*
+- * Libc hijacked symbol sendto(2).
+- */
+-LIBC_SENDTO_DECL
+-{
+-	if (!tsocks_libc_sendto) {
+-		tsocks_initialize();
+-		tsocks_libc_sendto = tsocks_find_libc_symbol(
+-				LIBC_SENDTO_NAME_STR, TSOCKS_SYM_EXIT_NOT_FOUND);
+-	}
+-
+-	return tsocks_sendto(LIBC_SENDTO_ARGS);
+-}


### PR DESCRIPTION
Otherwise fails with:
```
/home/builder/.termux-build/torsocks/src/src/lib/sendto.c:79:1: error: 
      redeclaration of 'sendto' must not have the 'overloadable' attribute
LIBC_SENDTO_DECL
^
/home/builder/.termux-build/torsocks/src/src/lib/torsocks.h:317:24: note: 
      expanded from macro 'LIBC_SENDTO_DECL'
                LIBC_SENDTO_RET_TYPE LIBC_SENDTO_NAME(LIBC_SENDTO_SIG...
                                     ^
/home/builder/.termux-build/torsocks/src/src/lib/torsocks.h:207:26: note: 
      expanded from macro 'LIBC_SENDTO_NAME'
#define LIBC_SENDTO_NAME sendto
                         ^
/home/builder/.termux-build/_lib/17-aarch64-21-v1/bin/../sysroot/usr/include/sys/socket.h:333:22: note: 
      previous unmarked overload of function is here
__socketcall ssize_t sendto(int __fd, const void* __buf, size_t __n, ...
                     ^
1 error generated.
Makefile:460: recipe for target 'sendto.lo' failed
```